### PR TITLE
CSN-10- Add build validation workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: Build Check
+
+on:
+  pull_request:
+    branches: [ main, master, develop ]
+  push:
+    branches: [ main, master, develop ]
+
+jobs:
+  build:
+    name: Build APK
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+      
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      
+      - name: Build Debug APK
+        run: ./gradlew assembleDebug
+      
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: debug-apk
+          path: app/build/outputs/apk/debug/*.apk
+


### PR DESCRIPTION
## 🚀 Add Build Validation Workflow

### What's Changed
- Added GitHub Actions workflow to validate app builds on PRs
- Ensures code compiles successfully before merging
- Uploads debug APK as artifact for verification

### Why
Prevents broken builds from being merged to main/develop branches by automatically building the app on every PR.

### Workflow Details
- **Runs on:** PRs and pushes to `main`, `master`, `develop`
- **Command:** `./gradlew assembleDebug`
- **Artifact:** Debug APK uploaded for download

### Next Steps
After this PR merges, add "Build APK" as a required status check in the branch protection ruleset.